### PR TITLE
Refactor sort_widget to use custom SortType

### DIFF
--- a/lib/ui/screens/Artists/artist_screen_controller.dart
+++ b/lib/ui/screens/Artists/artist_screen_controller.dart
@@ -160,7 +160,7 @@ class ArtistScreenController extends GetxController
     continuationInProgress = false;
   }
 
-  void onSort(bool sortByName, bool sortByDate, bool sortByDuration,
+  void onSort(SortType sortType,
       bool isAscending, String title) {
     if (sepataredContent[title] == null) {
       return;
@@ -168,11 +168,11 @@ class ArtistScreenController extends GetxController
     if (title == "Songs" || title == "Videos") {
       final songlist = sepataredContent[title]['results'].toList();
       sortSongsNVideos(
-          songlist, sortByName, sortByDate, sortByDuration, isAscending);
+          songlist, sortType, isAscending);
       sepataredContent[title]['results'] = songlist;
     } else if (title == "Albums" || title == "Singles") {
       final albumList = sepataredContent[title]['results'].toList();
-      sortAlbumNSingles(albumList, sortByName, sortByDate, isAscending);
+      sortAlbumNSingles(albumList, sortType, isAscending);
       sepataredContent[title]['results'] = albumList;
     }
     sepataredContent.refresh();

--- a/lib/ui/screens/Library/library.dart
+++ b/lib/ui/screens/Library/library.dart
@@ -41,12 +41,11 @@ class SongsLibraryWidget extends StatelessWidget {
               itemCountTitle: "${libSongsController.librarySongsList.length}",
               itemIcon: Icons.music_note_rounded,
               titleLeftPadding: 9,
-              isDateOptionRequired: true,
-              isDurationOptionRequired: true,
+              requiredSortTypes: buildSortTypeSet(true, true),
               isSearchFeatureRequired: true,
               isSongDeletetioFeatureRequired: true,
-              onSort: (p0, p1, p2, p3) {
-                libSongsController.onSort(p0, p1, p2, p3);
+              onSort: (type, ascending) {
+                libSongsController.onSort(type, ascending);
               },
               onSearch: libSongsController.onSearch,
               onSearchClose: libSongsController.onSearchClose,
@@ -149,9 +148,9 @@ class PlaylistNAlbumLibraryWidget extends StatelessWidget {
                     isSearchFeatureRequired: true,
                     itemCountTitle:
                         "${libralbumCntrller.libraryAlbums.length} ${"items".tr}",
-                    isDateOptionRequired: isAlbumContent,
-                    onSort: (a, b, c, d) {
-                      libralbumCntrller.onSort(a, b, d);
+                    requiredSortTypes: buildSortTypeSet(true),
+                    onSort: (type, ascending) {
+                      libralbumCntrller.onSort(type, ascending);
                     },
                     onSearch: libralbumCntrller.onSearch,
                     onSearchClose: libralbumCntrller.onSearchClose,
@@ -163,9 +162,9 @@ class PlaylistNAlbumLibraryWidget extends StatelessWidget {
                     isSearchFeatureRequired: true,
                     itemCountTitle:
                         "${librplstCntrller.libraryPlaylists.length} ${"items".tr}",
-                    isDateOptionRequired: isAlbumContent,
-                    onSort: (a, b, c, d) {
-                      librplstCntrller.onSort(a, d);
+                    requiredSortTypes: buildSortTypeSet(),
+                    onSort: (type, ascending) {
+                      librplstCntrller.onSort(type, ascending);
                     },
                     onSearch: librplstCntrller.onSearch,
                     onSearchClose: librplstCntrller.onSearchClose,
@@ -241,8 +240,8 @@ class LibraryArtistWidget extends StatelessWidget {
               isAdditionalOperationRequired: false,
               isSearchFeatureRequired: true,
               itemCountTitle: "${cntrller.libraryArtists.length} ${"items".tr}",
-              onSort: (sortByName, sortByDate, sortByDuration, isAscending) {
-                cntrller.onSort(sortByName, isAscending);
+              onSort: (type, ascending) {
+                cntrller.onSort(type, ascending);
               },
               onSearch: cntrller.onSearch,
               onSearchClose: cntrller.onSearchClose,

--- a/lib/ui/screens/Library/library_controller.dart
+++ b/lib/ui/screens/Library/library_controller.dart
@@ -71,11 +71,10 @@ class LibrarySongsController extends GetxController {
     isSongFetched.value = true;
   }
 
-  void onSort(
-      bool sortByName, bool sortByDate, bool sortByDuration, bool isAscending) {
+  void onSort(SortType sortType, bool isAscending) {
     final songlist = librarySongsList.toList();
     sortSongsNVideos(
-        songlist, sortByName, sortByDate, sortByDuration, isAscending);
+        songlist, sortType, isAscending);
     librarySongsList.value = songlist;
   }
 
@@ -409,10 +408,10 @@ class LibraryPlaylistsController extends GetxController
     syncPipedPlaylist();
   }
 
-  void onSort(bool sortByName, bool isAscending) {
+  void onSort(SortType sortType, bool isAscending) {
     final playlists = libraryPlaylists.toList();
     playlists.removeRange(0, 4);
-    sortPlayLists(playlists, sortByName, isAscending);
+    sortPlayLists(playlists, sortType, isAscending);
     playlists.insertAll(0, initPlst);
     libraryPlaylists.value = playlists;
   }
@@ -464,9 +463,9 @@ class LibraryAlbumsController extends GetxController {
     box.close();
   }
 
-  void onSort(bool sortByName, bool sortByDate, bool isAscending) {
+  void onSort(SortType sortType, bool isAscending) {
     final albumList = libraryAlbums.toList();
-    sortAlbumNSingles(albumList, sortByName, sortByDate, isAscending);
+    sortAlbumNSingles(albumList, sortType, isAscending);
     libraryAlbums.value = albumList;
   }
 
@@ -509,9 +508,9 @@ class LibraryArtistsController extends GetxController {
     box.close();
   }
 
-  void onSort(bool sortByName, bool isAscending) {
+  void onSort(SortType sortType, bool isAscending) {
     final artistList = libraryArtists.toList();
-    sortArtist(artistList, sortByName, isAscending);
+    sortArtist(artistList, sortType, isAscending);
     libraryArtists.value = artistList;
   }
 

--- a/lib/ui/screens/PlaylistNAlbum/playlistnalbum_screen.dart
+++ b/lib/ui/screens/PlaylistNAlbum/playlistnalbum_screen.dart
@@ -594,7 +594,7 @@ class PlaylistNAlbumScreen extends StatelessWidget {
                                         "${playListNAlbumScreenController.songList.length}",
                                     itemIcon: Icons.music_note_rounded,
                                     titleLeftPadding: 9,
-                                    isDurationOptionRequired: true,
+                                    requiredSortTypes: buildSortTypeSet(false, true),
                                     isPlaylistRearrageFeatureRequired:
                                         content.playlistId != "LIBRP" &&
                                             content.playlistId !=
@@ -602,9 +602,9 @@ class PlaylistNAlbumScreen extends StatelessWidget {
                                             content.playlistId != "SongsCache",
                                     isSongDeletetioFeatureRequired:
                                         content.playlistId != "LIBRP",
-                                    onSort: (a, b, c, d) {
+                                    onSort: (type, ascending) {
                                       playListNAlbumScreenController.onSort(
-                                          a, c, d);
+                                          type, ascending);
                                     },
                                     onSearch:
                                         playListNAlbumScreenController.onSearch,
@@ -644,10 +644,10 @@ class PlaylistNAlbumScreen extends StatelessWidget {
                                     "${playListNAlbumScreenController.songList.length}",
                                 itemIcon: Icons.music_note_rounded,
                                 titleLeftPadding: 9,
-                                isDurationOptionRequired: true,
-                                onSort: (a, b, c, d) {
+                                requiredSortTypes: buildSortTypeSet(false, true),
+                                onSort: (type, ascending) {
                                   playListNAlbumScreenController.onSort(
-                                      a, c, d);
+                                      type, ascending);
                                 },
                                 onSearch:
                                     playListNAlbumScreenController.onSearch,

--- a/lib/ui/screens/PlaylistNAlbum/playlistnalbum_screen_controller.dart
+++ b/lib/ui/screens/PlaylistNAlbum/playlistnalbum_screen_controller.dart
@@ -218,9 +218,9 @@ class PlayListNAlbumScreenController extends GetxController {
     isDownloaded.value = downloaded;
   }
 
-  void onSort(bool sortByName, bool sortByDuration, bool isAscending) {
+  void onSort(SortType sortType, bool isAscending) {
     final songlist_ = songList.toList();
-    sortSongsNVideos(songlist_, sortByName, false, sortByDuration, isAscending);
+    sortSongsNVideos(songlist_, sortType, isAscending);
     songList.value = songlist_;
   }
 

--- a/lib/ui/screens/Search/search_result_screen_controller.dart
+++ b/lib/ui/screens/Search/search_result_screen_controller.dart
@@ -5,6 +5,7 @@ import 'package:harmonymusic/ui/screens/Settings/settings_screen_controller.dart
 import '../../../utils/helper.dart';
 import '../Home/home_screen_controller.dart';
 import '/services/music_service.dart';
+import '/ui/widgets/sort_widget.dart';
 
 class SearchResultScreenController extends GetxController
     with GetTickerProviderStateMixin {
@@ -141,24 +142,23 @@ class SearchResultScreenController extends GetxController
     }
   }
 
-  void onSort(bool sortByName, bool sortByDate, bool sortByDuration,
-      bool isAscending, String title) {
+  void onSort(SortType sortType, bool isAscending, String title) {
     if (title == "Songs" || title == "Videos") {
       final songList = separatedResultContent[title].toList();
       sortSongsNVideos(
-          songList, sortByName, sortByDate, sortByDuration, isAscending);
+          songList, sortType, isAscending);
       separatedResultContent[title] = songList;
     } else if (title.contains('playlists')) {
       final playlists = separatedResultContent[title].toList();
-      sortPlayLists(playlists, sortByName, isAscending);
+      sortPlayLists(playlists, sortType, isAscending);
       separatedResultContent[title] = playlists;
     } else if (title == "Artists") {
       final artistList = separatedResultContent[title].toList();
-      sortArtist(artistList, sortByName, isAscending);
+      sortArtist(artistList, sortType, isAscending);
       separatedResultContent[title] = artistList;
     } else if (title == "Albums") {
       final albumList = separatedResultContent[title].toList();
-      sortAlbumNSingles(albumList, sortByName, sortByDate, isAscending);
+      sortAlbumNSingles(albumList, sortType, isAscending);
       separatedResultContent[title] = albumList;
     }
   }

--- a/lib/ui/widgets/separate_tab_item_widget.dart
+++ b/lib/ui/widgets/separate_tab_item_widget.dart
@@ -74,14 +74,11 @@ class SeparateTabItemWidget extends StatelessWidget {
                     titleLeftPadding: 9,
                     itemCountTitle:
                         "${isResultWidget ? (searchResController?.separatedResultContent[title] ?? []).length : (artistController?.sepataredContent[title] != null ? artistController?.sepataredContent[title]['results'] : []).length} ${"items".tr}",
-                    isDurationOptionRequired:
-                        title == "Songs" || title == "Videos",
-                    isDateOptionRequired:
-                        title == 'Albums' || title == "Singles",
-                    onSort: (a, b, c, d) {
+                    requiredSortTypes: buildSortTypeSet(title == 'Albums' || title == "Singles", title == "Songs" || title == "Videos"),
+                    onSort: (type, ascending) {
                       isResultWidget
-                          ? searchResController!.onSort(a, b, c, d, title)
-                          : artistController?.onSort(a, b, c, d, title);
+                          ? searchResController!.onSort(type, ascending, title)
+                          : artistController?.onSort(type, ascending, title);
                     },
                     onSearch: artistController?.onSearch,
                     onSearchClose: artistController?.onSearchClose,

--- a/lib/ui/widgets/sort_widget.dart
+++ b/lib/ui/widgets/sort_widget.dart
@@ -3,6 +3,27 @@ import 'package:get/get.dart';
 
 enum OperationMode { arrange, delete, addToPlaylist, none }
 
+enum SortType {
+  Name,
+  Date,
+  Duration,
+  RecentlyPlayed,
+}
+
+Set<SortType> buildSortTypeSet([bool dateRequired = false, bool durationRequired = false, bool recentlyPlayedRequired = false]) {
+  Set<SortType> requiredSortTypes = {};
+  if (dateRequired) {
+    requiredSortTypes.add(SortType.Date);
+  }
+  if (durationRequired) {
+    requiredSortTypes.add(SortType.Duration);
+  }
+  if (recentlyPlayedRequired) {
+    requiredSortTypes.add(SortType.RecentlyPlayed);
+  }
+  return requiredSortTypes;
+}
+
 class SortWidget extends StatelessWidget {
   /// Additional operations - Delete Multiple songs, Rearrage offline playlist, Add Multiple songs to playlist
   const SortWidget({
@@ -11,8 +32,7 @@ class SortWidget extends StatelessWidget {
     this.itemCountTitle = '',
     this.titleLeftPadding = 18,
     this.isAdditionalOperationRequired = true,
-    this.isDateOptionRequired = false,
-    this.isDurationOptionRequired = false,
+    this.requiredSortTypes = const <SortType>{SortType.Name},
     this.isSearchFeatureRequired = false,
     this.isPlaylistRearrageFeatureRequired = false,
     this.isSongDeletetioFeatureRequired = false,
@@ -33,8 +53,7 @@ class SortWidget extends StatelessWidget {
   final IconData? itemIcon;
   final bool isAdditionalOperationRequired;
   final double titleLeftPadding;
-  final bool isDurationOptionRequired;
-  final bool isDateOptionRequired;
+  final Set<SortType> requiredSortTypes;
   final bool isSearchFeatureRequired;
   final bool isSongDeletetioFeatureRequired;
   final bool isPlaylistRearrageFeatureRequired;
@@ -45,7 +64,7 @@ class SortWidget extends StatelessWidget {
   final Function(String?)? onSearchStart;
   final Function(String, String?)? onSearch;
   final Function(String?)? onSearchClose;
-  final Function(bool, bool, bool, bool) onSort;
+  final Function(SortType, bool) onSort;
 
   @override
   Widget build(BuildContext context) {
@@ -72,7 +91,7 @@ class SortWidget extends StatelessWidget {
               ),
               Obx(
                 () => IconButton(
-                  color: controller.sortByName.value
+                  color: controller.sortType.value == SortType.Name
                       ? Theme.of(context).textTheme.bodySmall!.color
                       : Theme.of(context).colorScheme.secondary,
                   icon: const Icon(Icons.sort_by_alpha_rounded),
@@ -85,9 +104,9 @@ class SortWidget extends StatelessWidget {
                   },
                 ),
               ),
-              isDateOptionRequired
+              requiredSortTypes.contains(SortType.Date)
                   ? Obx(() => IconButton(
-                        color: controller.sortByDate.value
+                        color: controller.sortType.value == SortType.Date
                             ? Theme.of(context).textTheme.bodySmall!.color
                             : Theme.of(context).colorScheme.secondary,
                         icon: const Icon(Icons.calendar_month_rounded),
@@ -100,9 +119,9 @@ class SortWidget extends StatelessWidget {
                         },
                       ))
                   : const SizedBox.shrink(),
-              isDurationOptionRequired
+              requiredSortTypes.contains(SortType.Duration)
                   ? Obx(() => IconButton(
-                        color: controller.sortByDuration.value
+                        color: controller.sortType.value == SortType.Duration
                             ? Theme.of(context).textTheme.bodySmall!.color
                             : Theme.of(context).colorScheme.secondary,
                         icon: const Icon(Icons.timer_rounded),
@@ -313,10 +332,8 @@ class SortWidget extends StatelessWidget {
 }
 
 class SortWidgetController extends GetxController {
-  final sortByName = true.obs;
+  final Rx<SortType> sortType = SortType.Name.obs;
   final isAscending = true.obs;
-  final sortByDate = false.obs;
-  final sortByDuration = false.obs;
   final isSearchingEnabled = false.obs;
   final isRearraningEnabled = false.obs;
   final isDeletionEnabled = false.obs;
@@ -335,33 +352,23 @@ class SortWidgetController extends GetxController {
   }
 
   void onSortByName(Function onSort) {
-    sortByName.value = true;
-    sortByDate.value = false;
-    sortByDuration.value = false;
-    onSort(sortByName.value, sortByDate.value, sortByDuration.value,
-        isAscending.value);
+    sortType.value = SortType.Name;
+    onSort(sortType.value, isAscending.value);
   }
 
   void onSortByDuration(Function onSort) {
-    sortByName.value = false;
-    sortByDate.value = false;
-    sortByDuration.value = true;
-    onSort(sortByName.value, sortByDate.value, sortByDuration.value,
-        isAscending.value);
+    sortType.value = SortType.Duration;
+    onSort(sortType.value, isAscending.value);
   }
 
   void onSortByDate(Function onSort) {
-    sortByName.value = false;
-    sortByDate.value = true;
-    sortByDuration.value = false;
-    onSort(sortByName.value, sortByDate.value, sortByDuration.value,
-        isAscending.value);
+    sortType.value = SortType.Date;
+    onSort(sortType.value, isAscending.value);
   }
 
   void onAscendNDescend(Function onSort) {
     isAscending.value = !isAscending.value;
-    onSort(sortByName.value, sortByDate.value, sortByDuration.value,
-        isAscending.value);
+    onSort(sortType.value, isAscending.value);
   }
 
   void toggleSearch() {

--- a/lib/utils/helper.dart
+++ b/lib/utils/helper.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
 
 import '/ui/navigator.dart';
+import '/ui/widgets/sort_widget.dart';
 
 void printERROR(dynamic text, {String tag = "Harmony Music"}) {
   debugPrint("\x1B[31m[$tag]: $text\x1B[34m");
@@ -27,71 +28,129 @@ String? getCurrentRouteName() {
 
 void sortSongsNVideos(
   List songlist,
-  bool sortByName,
-  bool sortByDate,
-  bool sortByDuration,
+  SortType sortType,
   bool isAscending,
 ) {
-  if (sortByName) {
-    songlist.sort((a, b) => isAscending
-        ? a.title.toLowerCase().compareTo(b.title.toLowerCase())
-        : b.title.toLowerCase().compareTo(a.title.toLowerCase()));
-  } else if (sortByDate) {
-    songlist.sort((a, b) {
-      if (a.extras!['date'] == null || b.extras!['date'] == null) {
-        return 0.compareTo(0);
-      }
-      return isAscending
-          ? (a.extras!['date']).compareTo(b.extras!['date'])
-          : (b.extras!['date']).compareTo(a.extras!['date']);
-    });
-  } else if (sortByDuration) {
-    songlist.sort((a, b) => isAscending
-        ? (a.duration ?? Duration.zero).compareTo(b.duration ?? Duration.zero)
-        : (b.duration ?? Duration.zero).compareTo(a.duration ?? Duration.zero));
+  Comparator compareFunction;
+
+  switch (sortType) {
+    case SortType.Date:
+      compareFunction = (a, b) {
+        if (a.extras!['date'] == null || b.extras!['date'] == null) {
+          return 0.compareTo(0);
+        }
+        return a.extras!['date'].compareTo(b.extras!['date']);
+      };
+      break;
+    case SortType.Duration:
+      compareFunction = (a, b) => (a.duration ?? Duration.zero).compareTo(b.duration ?? Duration.zero);
+    case SortType.Name:
+    default:
+      compareFunction = (a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase());
+      break;
+  }
+
+  songlist.sort(compareFunction);
+
+  if (!isAscending) {
+    List reversed = songlist.reversed.toList();
+    songlist.clear();
+    songlist.addAll(reversed);
   }
 }
 
 void sortAlbumNSingles(
   List albumList,
-  bool sortByName,
-  bool sortByDate,
+  SortType sortType,
   bool isAscending,
 ) {
-  if (sortByName) {
-    albumList.sort((a, b) => isAscending
-        ? a.title.toLowerCase().compareTo(b.title.toLowerCase())
-        : b.title.toLowerCase().compareTo(a.title.toLowerCase()));
-  } else if (sortByDate) {
-    albumList.sort((a, b) {
+  Comparator compareFunction;
+
+  switch (sortType) {
+    case SortType.Date:
+      compareFunction = (a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase());
+      break;
+    case SortType.Name:
+    default:
+      compareFunction = (a, b) {
       if (a.year == null || b.year == null) {
         return 0.compareTo(0);
       }
-      return isAscending
-          ? a.year!.compareTo(b.year!)
-          : b.year!.compareTo(a.year!);
-    });
+      return a.year!.compareTo(b.year!);
+    };
+      break;
+  }
+
+  albumList.sort(compareFunction);
+
+  if (!isAscending) {
+    List reversed = albumList.reversed.toList();
+    albumList.clear();
+    albumList.addAll(reversed);
   }
 }
 
 void sortPlayLists(
   List playlists,
-  bool sortByName,
+  SortType sortType,
   bool isAscending,
 ) {
-  playlists.sort((a, b) => isAscending
-      ? a.title.toLowerCase().compareTo(b.title.toLowerCase())
-      : b.title.toLowerCase().compareTo(a.title.toLowerCase()));
+  Comparator compareFunction;
+  int titleSort(a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase());
+
+  switch (sortType) {
+    case SortType.RecentlyPlayed:
+      compareFunction = (a, b) {
+        DateTime? alp = a.lastPlayed;
+        DateTime? blp = b.lastPlayed;
+        if (alp == null && blp == null) {
+          return titleSort(a, b);
+        }
+        if (alp == null) {
+          return 1;
+        }
+        if (blp == null) {
+          return -1;
+        }
+        return blp.compareTo(alp);
+      };
+      break;
+    case SortType.Name:
+    default:
+      compareFunction = titleSort;
+      break;
+  }
+
+  playlists.sort(compareFunction);
+
+  if (!isAscending) {
+    List reversed = playlists.reversed.toList();
+    playlists.clear();
+    playlists.addAll(reversed);
+  }
 }
 
 void sortArtist(
   List artistList,
-  bool sortByName,
+  SortType sortType,
   bool isAscending,
 ) {
-  artistList.sort((a, b) => isAscending
-      ? a.name.toLowerCase().compareTo(b.name.toLowerCase())
-      : b.name.toLowerCase().compareTo(a.name.toLowerCase()));
+  Comparator compareFunction;
+
+  switch (sortType) {
+    case SortType.Name:
+    default:
+      compareFunction = (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase());
+      break;
+  }
+
+  artistList.sort(compareFunction);
+
+  if (!isAscending) {
+    List reversed = artistList.reversed.toList();
+    artistList.clear();
+    artistList.addAll(reversed);
+  }
 }
 
 /// Return true if new version available


### PR DESCRIPTION
Previously sort_widget used a boolean for every available sort type, like ByName, ByDate, ByDuration.
This makes it hard to add more sort options and results in overall less readable code.
To combat this, this commit adds an enum SortType, that is instead used to express the type of sorting the sort widget should apply.