### PR TITLE
fix: allow use of qt window decorations

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -5,6 +5,10 @@
 #include <gdk/gdkx.h>
 #endif
 
+#ifdef GDK_WINDOWING_WAYLAND
+#include <gdk/gdkwayland.h>
+#endif
+
 #include "flutter/generated_plugin_registrant.h"
 
 struct _MyApplication {
@@ -28,6 +32,7 @@ static void my_application_activate(GApplication* application) {
   // If running on Wayland assume the header bar will work (may need changing
   // if future cases occur).
   gboolean use_header_bar = TRUE;
+
 #ifdef GDK_WINDOWING_X11
   GdkScreen* screen = gtk_window_get_screen(window);
   if (GDK_IS_X11_SCREEN(screen)) {
@@ -37,6 +42,21 @@ static void my_application_activate(GApplication* application) {
     }
   }
 #endif
+
+#ifdef GDK_WINDOWING_WAYLAND
+  GdkDisplay* display = gtk_widget_get_display(GTK_WIDGET(window));
+  if (GDK_IS_WAYLAND_DISPLAY(display)) {
+    // Check the XDG_CURRENT_DESKTOP environment variable to determine the
+    // desktop environment.
+    const gchar* current_desktop = g_getenv("XDG_CURRENT_DESKTOP");
+    if (current_desktop != NULL && g_str_has_prefix(current_desktop, "GNOME")) {
+      use_header_bar = TRUE;
+    } else {
+      use_header_bar = FALSE;
+    }
+  }
+#endif
+
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));


### PR DESCRIPTION
Currently, Flutter defaults to always using GTK window decorations regardless of
the window manager, when running Wayland. This makes the app look out of place
on KDE Plasma and other Qt-based desktop environments.

This change checks the XDG_CURRENT_DESKTOP environment variable to determine the
running desktop environment, and if it is GNOME continues to use the GTK header,
otherwise it uses the Qt header.

| Before | After |
|--------|--------|
| ![image](https://github.com/anandnet/Harmony-Music/assets/9575627/819a7709-af49-4230-a12a-c3c2e93c587f) | ![image](https://github.com/anandnet/Harmony-Music/assets/9575627/06fbb208-9dd6-464f-8a21-e3e7f264c421) | 

Now in the `after` screenshot, the window has native decorations on KDE with user-customized controls for things like `pin to all workspaces`.