### PR TITLE
Empty Search fix and search edit

### DIFF
--- a/lib/ui/screens/Search/search_screen.dart
+++ b/lib/ui/screens/Search/search_screen.dart
@@ -70,7 +70,8 @@ class SearchScreen extends StatelessWidget {
                       controller: searchScreenController.textInputController,
                       textInputAction: TextInputAction.search,
                       onChanged: searchScreenController.onChanged,
-                      onSubmitted: (val) {
+                      onSubmitted: (String val) {
+                        val = val.trim();
                         if (val.contains("https://")) {
                           searchScreenController.filterLinks(Uri.parse(val));
                           searchScreenController.reset();

--- a/lib/ui/screens/Search/search_screen.dart
+++ b/lib/ui/screens/Search/search_screen.dart
@@ -72,6 +72,8 @@ class SearchScreen extends StatelessWidget {
                       onChanged: searchScreenController.onChanged,
                       onSubmitted: (String val) {
                         val = val.trim();
+                        if (val.isEmpty) return;
+
                         if (val.contains("https://")) {
                           searchScreenController.filterLinks(Uri.parse(val));
                           searchScreenController.reset();

--- a/lib/ui/widgets/search_related_widgets.dart
+++ b/lib/ui/widgets/search_related_widgets.dart
@@ -1,6 +1,10 @@
+import 'dart:developer';
+
 import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:harmonymusic/ui/navigator.dart';
+import 'package:harmonymusic/ui/screens/Search/search_screen_controller.dart';
 
 import '../screens/Search/search_result_screen_controller.dart';
 import '/models/album.dart';
@@ -17,6 +21,8 @@ class ResultWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final SearchResultScreenController searchResScrController =
         Get.find<SearchResultScreenController>();
+    final SearchScreenController searchScreenController =
+        Get.find<SearchScreenController>();
     final topPadding = context.isLandscape ? 50.0 : 80.0;
     return Obx(
       () => Center(
@@ -28,19 +34,29 @@ class ResultWidget extends StatelessWidget {
             child: searchResScrController.isResultContentFetced.value
                 ? Column(children: [
                     if (!isv2Used)
-                      Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          "searchRes".tr,
-                          style: Theme.of(context).textTheme.titleLarge,
-                        ),
-                      ),
-                    if (!isv2Used)
-                      Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          "${"for1".tr} \"${searchResScrController.queryString.value}\"",
-                          style: Theme.of(context).textTheme.titleMedium,
+                      GestureDetector(
+                        onTap: () {
+                          searchScreenController.textInputController.text =
+                              searchResScrController.queryString.value;
+                          Navigator.pop(context);
+                        },
+                        child: Column(
+                          children: [
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text(
+                                "searchRes".tr,
+                                style: Theme.of(context).textTheme.titleMedium,
+                              ),
+                            ),
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text(
+                                "${"for1".tr} \"${searchResScrController.queryString.value}\"",
+                                style: Theme.of(context).textTheme.titleLarge,
+                              ),
+                            ),
+                          ],
                         ),
                       ),
                     const SizedBox(


### PR DESCRIPTION
These changes makes sure that the user is not able to make empty searches i.e. search for nothing ("  ") and also removes leading and trailing spaces from searches, which doesn't look that good (eg below). Beside this, this PR also include change requested in issue #391 and now allows user to edit the searched text by tapping on it. 

(A slight change is made in search result header, making the actual searched text bigger and making the 'Search results' text smaller, as it seemed a bit more logical to me to highlight the actual text)

![image](https://github.com/user-attachments/assets/f49dd252-16c2-473f-abe5-8bf61db1f6e2)
